### PR TITLE
updated dataset versions

### DIFF
--- a/flan/tasks.py
+++ b/flan/tasks.py
@@ -1114,7 +1114,7 @@ def _process_paws_wiki(example):
 
 TASK_CONFIGS['paws_wiki'] = _TaskConfig(
     source=seqio.TfdsDataSource(
-        tfds_name='paws_wiki:1.0.0', splits=SPLITS_DICT),
+        tfds_name='paws_wiki:1.1.0', splits=SPLITS_DICT),
     preprocessors=[
         _process_paws_wiki,
         preprocessors.format_options,
@@ -1175,7 +1175,7 @@ def _process_glue_mrpc(example):
 
 TASK_CONFIGS['glue_mrpc'] = _TaskConfig(
     source=seqio.TfdsDataSource(
-        tfds_name='glue/mrpc:1.0.0',
+        tfds_name='glue/mrpc:2.0.0',
         splits={
             'train': f'train[:-{NUM_VAL_EXAMPLES}]',
             'validation': f'train[-{NUM_VAL_EXAMPLES}:]',
@@ -1208,7 +1208,7 @@ def _process_glue_qqp(example):
 
 TASK_CONFIGS['glue_qqp'] = _TaskConfig(
     source=seqio.TfdsDataSource(
-        tfds_name='glue/qqp:1.0.0',
+        tfds_name='glue/qqp:2.0.0',
         splits={
             'train': f'train[:{NUM_TRAIN_EXAMPLES}]',
             'validation': f'train[-{NUM_VAL_EXAMPLES}:]',
@@ -1542,7 +1542,7 @@ def _process_common_gen(example):
 
 TASK_CONFIGS['common_gen'] = _TaskConfig(
     source=seqio.TfdsDataSource(
-        tfds_name='gem/common_gen:1.0.0',
+        tfds_name='gem/common_gen:1.1.0',
         splits={
             'train': f'train[:{NUM_TRAIN_EXAMPLES}]',
             'validation': f'train[-{NUM_VAL_EXAMPLES}:]',
@@ -1579,7 +1579,7 @@ def _process_dart(example):
 
 TASK_CONFIGS['dart'] = _TaskConfig(
     source=seqio.TfdsDataSource(
-        tfds_name='gem/dart:1.0.0',
+        tfds_name='gem/dart:1.1.0',
         splits={
             'train': f'train[:{NUM_TRAIN_EXAMPLES}]',
             'validation': f'train[-{NUM_VAL_EXAMPLES}:]',
@@ -1612,7 +1612,7 @@ def _process_e2e_nlg(example):
 
 TASK_CONFIGS['e2e_nlg'] = _TaskConfig(
     source=seqio.TfdsDataSource(
-        tfds_name='gem/e2e_nlg:1.0.0',
+        tfds_name='gem/e2e_nlg:1.1.0',
         splits={
             'train': f'train[:{NUM_TRAIN_EXAMPLES}]',
             'validation': f'train[-{NUM_VAL_EXAMPLES}:]',
@@ -1645,7 +1645,7 @@ def _process_web_nlg_en(example):
 
 TASK_CONFIGS['web_nlg_en'] = _TaskConfig(
     source=seqio.TfdsDataSource(
-        tfds_name='gem/web_nlg_en:1.0.0',
+        tfds_name='gem/web_nlg_en:1.1.0',
         splits={
             'train': f'train[:{NUM_TRAIN_EXAMPLES}]',
             'validation': f'train[-{NUM_VAL_EXAMPLES}:]',
@@ -1828,7 +1828,7 @@ def _process_cola(example):
 
 TASK_CONFIGS['cola'] = _TaskConfig(
     source=seqio.TfdsDataSource(
-        tfds_name='glue/cola:1.0.0',
+        tfds_name='glue/cola:2.0.0',
         splits={
             'train': f'train[:-{NUM_VAL_EXAMPLES}]',
             'validation': f'train[-{NUM_VAL_EXAMPLES}:]',
@@ -1857,7 +1857,7 @@ def _process_sst2(example):
 
 TASK_CONFIGS['sst2'] = _TaskConfig(
     source=seqio.TfdsDataSource(
-        tfds_name='glue/sst2:1.0.0',
+        tfds_name='glue/sst2:2.0.0',
         splits={
             'train': f'train[:{NUM_TRAIN_EXAMPLES}]',
             'validation': f'train[-{NUM_VAL_EXAMPLES}:]',
@@ -1887,7 +1887,7 @@ def _process_mnli(example):
 
 TASK_CONFIGS['mnli_matched'] = _TaskConfig(
     source=seqio.TfdsDataSource(
-        tfds_name='glue/mnli:1.0.0',
+        tfds_name='glue/mnli:2.0.0',
         splits={
             'train': f'train[:{NUM_TRAIN_EXAMPLES}]',
             'validation': f'train[-{NUM_VAL_EXAMPLES}:]',
@@ -1903,7 +1903,7 @@ TASK_CONFIGS['mnli_matched'] = _TaskConfig(
 
 TASK_CONFIGS['mnli_mismatched'] = _TaskConfig(
     source=seqio.TfdsDataSource(
-        tfds_name='glue/mnli:1.0.0',
+        tfds_name='glue/mnli:2.0.0',
         splits={
             'train': f'train[:{NUM_TRAIN_EXAMPLES}]',
             'validation': f'train[-{NUM_VAL_EXAMPLES}:]',
@@ -1933,7 +1933,7 @@ def _process_qnli(example):
 
 TASK_CONFIGS['qnli'] = _TaskConfig(
     source=seqio.TfdsDataSource(
-        tfds_name='glue/qnli:1.0.0',
+        tfds_name='glue/qnli:2.0.0',
         splits={
             'train': f'train[:{NUM_TRAIN_EXAMPLES}]',
             'validation': f'train[-{NUM_VAL_EXAMPLES}:]',
@@ -1963,7 +1963,7 @@ def _process_wnli(example):
 
 TASK_CONFIGS['wnli'] = _TaskConfig(
     source=seqio.TfdsDataSource(
-        tfds_name='glue/wnli:1.0.0',
+        tfds_name='glue/wnli:2.0.0',
         splits={
             'train': 'train[:-30]',
             'validation': 'train[-30:]',
@@ -2067,7 +2067,7 @@ def _process_stsb(example):
 
 TASK_CONFIGS['stsb'] = _TaskConfig(
     source=seqio.TfdsDataSource(
-        tfds_name='glue/stsb:1.0.0',
+        tfds_name='glue/stsb:2.0.0',
         splits={
             'train': 'train[:-100]',
             'validation': 'train[-100:]',
@@ -2183,7 +2183,7 @@ def _filter_hellaswag(dataset):
 
 TASK_CONFIGS['hellaswag'] = _TaskConfig(
     source=seqio.TfdsDataSource(
-        tfds_name='hellaswag:0.0.1',
+        tfds_name='hellaswag:1.1.0',
         splits={
             'train': f'train[:{NUM_TRAIN_EXAMPLES}]',
             'validation': f'train[-{NUM_VAL_EXAMPLES}:]',


### PR DESCRIPTION
This PR updates the necessary dataset versions. Without the updates, these datasets cannot be downloaded.
To reproduce, run
```
import seqio
import mixtures, task_splits, tasks
dataset = seqio.get_mixture_or_task("flan_inter_cluster_split_0_10templates_train").get_dataset(
    sequence_length={"inputs": 4096, "targets": 4096},
)
```
