### PR TITLE
More README Info + Fixing MMLU Filters + Adding Metadata

### DIFF
--- a/flan/v2/README.md
+++ b/flan/v2/README.md
@@ -21,7 +21,11 @@ You can import `flan/v2/mixtures.py` and directly use the mixtures, or combine a
 PYTHONPATH=. python flan/v2/run_example.py
 ```
 
-NB: Unfortunately a couple datasets from the Flan Collection, used to train Flan-T5 and Flan-PaLM, could not be included in these generation scripts due to legal constraints. Those are Dr Repair datasets (https://github.com/michiyasunaga/DrRepair), Deepmind Code Contests (https://github.com/deepmind/code_contests), and Task Master (https://github.com/google-research-datasets/Taskmaster). As a result, we have no Program Synthesis submixture, as described in the paper. However, these datasets comprise a small minority of overall training examples and their exclusion should have negligible effect on results reported in the paper.
+NB #1: These scripts download and process dozens of GBs of data, which is usually not feasible in a single run. We recommend starting with submixtures like `cot_submix`, `flan2021_submix`, `dialog_submix`, `t0_submix` and `niv2_submix`, as shown in `flan/v2/run_example.py`. If you plan to use Seqio/T5X for training then we recommend caching the datasets, following these [instructions](https://github.com/google/seqio#optional-offline-caching). If not, you can use the above script to collect the data as raw text/json.
+
+NB #2: Unfortunately a couple datasets from the Flan Collection, used to train Flan-T5 and Flan-PaLM, could not be included in these generation scripts due to legal constraints. Those are Dr Repair datasets (https://github.com/michiyasunaga/DrRepair), Deepmind Code Contests (https://github.com/deepmind/code_contests), and Task Master (https://github.com/google-research-datasets/Taskmaster). As a result, we have no Program Synthesis submixture, as described in the paper. However, these datasets comprise a small minority of overall training examples and their exclusion should have negligible effect on results reported in the paper.
+
+NB #3: If you hit checksum errors from Tensorflow Datasets (TFDS), try updating to the latest `tfds-nightly` then loading the problematic dataset directly with [tfds.load(...)](https://www.tensorflow.org/datasets/api_docs/python/tfds/load). As dataset requirements may change over time (e.g. approvals), occassionally some datasets may no longer be available or require manual download, as suggested [here](https://github.com/google-research/FLAN/issues/37#issuecomment-1479810887).
 
 ## Citation
 Please cite the following if you found The Flan Collection, our [paper](https://arxiv.org/abs/2301.13688), or these resources useful.

--- a/flan/v2/run_example.py
+++ b/flan/v2/run_example.py
@@ -84,6 +84,9 @@ selected_mixture = seqio.get_mixture_or_task('cot_zsopt')
 
 # 3. Example use cases to use the full Flan Collection:
 # selected_mixture = seqio.get_mixture_or_task('flan2022_submix')
+# This last one (the final Flan Collection mixture) may take too long to run if not
+# cached. We suggest starting by caching each of:
+# `cot_submix`, `flan2021_submix`, `dialog_submix`, `t0_submix`, `niv2_submix`.
 
 # If you're using Seqio, we suggest caching your mixture as they take a while to generate.
 # If you want to read out the post-processed examples into a file, we suggest using the

--- a/flan/v2/task_configs.py
+++ b/flan/v2/task_configs.py
@@ -218,7 +218,7 @@ niv2_posex_exp_lookup = tf.lookup.StaticHashTable(
 NIV2_MMLU_TASK_KEYS = tf.constant([
     k.split(".")[0]
     for k in NATINST_META_DATA.keys()
-    if int(k.split("_")[0].replace("task", "")) in list(range(685, 738))
+    if int(k.split("_")[0].replace("task", "")) in list(range(685, 738)) + [664, 665, 666, 667]
 ])
 
 

--- a/flan/v2/task_configs_v1.py
+++ b/flan/v2/task_configs_v1.py
@@ -624,6 +624,8 @@ def _process_opinion_abstracts_rotten_tomatoes(example):
   }
 
 
+oart_prep_fn = functools.partial(prep.add_source_info,
+    task_name="opinion_abstracts_rotten_tomatoes", task_source="Flan2021")
 TASK_CONFIGS['opinion_abstracts_rotten_tomatoes'] = TaskConfig(
     source=seqio.TfdsDataSource(
         tfds_name='opinion_abstracts/rotten_tomatoes:1.0.0',
@@ -633,6 +635,7 @@ TASK_CONFIGS['opinion_abstracts_rotten_tomatoes'] = TaskConfig(
             'test': 'train[-500:]',
         }),
     preprocessors=[
+        oart_prep_fn,
         _process_opinion_abstracts_rotten_tomatoes,
     ],
     postprocess_fn=None,
@@ -652,7 +655,8 @@ def _process_opinion_abstracts_idebate(example):
           prep.numbered_items_str(example['_argument_sentences']['value'][:10]),
   }
 
-
+oaid_prep_fn = functools.partial(prep.add_source_info,
+    task_name="opinion_abstracts_idebate", task_source="Flan2021")
 TASK_CONFIGS['opinion_abstracts_idebate'] = TaskConfig(
     source=seqio.TfdsDataSource(
         tfds_name='opinion_abstracts/idebate:1.0.0',
@@ -662,6 +666,7 @@ TASK_CONFIGS['opinion_abstracts_idebate'] = TaskConfig(
             'test': 'train[-500:]',
         }),
     preprocessors=[
+        oaid_prep_fn,
         _process_opinion_abstracts_idebate,
     ],
     postprocess_fn=None,
@@ -1454,10 +1459,13 @@ def _process_para_crawl_enes(example):
   }
 
 
+pc_prep_fn = functools.partial(prep.add_source_info,
+    task_name="para_crawl_enes", task_source="Flan2021")
 TASK_CONFIGS['para_crawl_enes'] = TaskConfig(
     source=seqio.TfdsDataSource(
         tfds_name='para_crawl/enes:1.2.0', splits=PARACRAWL_SPLITS_DICT),
     preprocessors=[
+        pc_prep_fn,
         _process_para_crawl_enes,
     ],
     postprocess_fn=None,
@@ -1754,7 +1762,8 @@ def _filter_true_case(dataset):
 
   return dataset.filter(my_fn)
 
-
+tc_prep_fn = functools.partial(prep.add_source_info,
+    task_name="true_case", task_source="Flan2021")
 true_case_val_end = NUM_TRAIN_EXAMPLES + NUM_VAL_EXAMPLES
 TASK_CONFIGS['true_case'] = TaskConfig(
     source=seqio.TfdsDataSource(
@@ -1765,6 +1774,7 @@ TASK_CONFIGS['true_case'] = TaskConfig(
             'test': 'train[-3000:]',
         }),
     preprocessors=[
+        tc_prep_fn,
         _process_true_case,
         _filter_true_case,
     ],
@@ -1790,7 +1800,8 @@ def _filter_fix_punct(dataset):
 
   return dataset.filter(my_fn)
 
-
+fp_prep_fn = functools.partial(prep.add_source_info,
+    task_name="fix_punct", task_source="Flan2021")
 fix_punct_train_end = true_case_val_end + NUM_TRAIN_EXAMPLES
 fix_punct_val_end = fix_punct_train_end + NUM_VAL_EXAMPLES
 TASK_CONFIGS['fix_punct'] = TaskConfig(
@@ -1819,7 +1830,8 @@ def _process_word_segment(example):
       'answer': text,
   }
 
-
+ws_prep_fn = functools.partial(prep.add_source_info,
+    task_name="word_segment", task_source="Flan2021")
 w_seg_train_end = fix_punct_val_end + NUM_TRAIN_EXAMPLES
 w_seg_val_end = w_seg_train_end + NUM_VAL_EXAMPLES
 TASK_CONFIGS['word_segment'] = TaskConfig(
@@ -1831,6 +1843,7 @@ TASK_CONFIGS['word_segment'] = TaskConfig(
             'test': 'train[-3000:]',
         }),
     preprocessors=[
+        ws_prep_fn,
         _process_word_segment,
     ],
     postprocess_fn=None,


### PR DESCRIPTION
This PR patches a couple fixes:

- We add more detail and information to the README for users to navigate challenging circumstances when TFDS has bugs or TFDS Dataset requirements change.
- Unlike in our internal implementation, this version accidentally didn't filter out 4 of the 57 MMLU eval tasks from training in the NIv2 submixture. We now correctly filter those out.
- Some of the FLAN2021 datasets were missing metadata fields, so we now add those.